### PR TITLE
Reduce sleep timeout for pocket lock

### DIFF
--- a/core/java/android/pocket/PocketManager.java
+++ b/core/java/android/pocket/PocketManager.java
@@ -148,7 +148,7 @@ public class PocketManager {
                 if (isPocketViewShowing) {
                     if (DEBUG) Log.v(TAG, "Setting pocket timer");
                     mHandler.removeCallbacks(mPocketLockTimeout); // remove any pending requests
-                    mHandler.postDelayed(mPocketLockTimeout, 10 * DateUtils.SECOND_IN_MILLIS);
+                    mHandler.postDelayed(mPocketLockTimeout, 3 * DateUtils.SECOND_IN_MILLIS);
                     mPocketViewTimerActive = true;
                 } else {
                     if (DEBUG) Log.v(TAG, "Clearing pocket timer");


### PR DESCRIPTION
*if the proximity value changes within 10s, pocketlock exits to lockscreen. Inorder to avoid that reduce timeout to 3s

Signed-off-by: RadixCube <radixcube@gmail.com>