### PR TITLE
base: blur level: Fix radius out of range

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/NotificationMediaManager.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/NotificationMediaManager.java
@@ -795,8 +795,8 @@ public class NotificationMediaManager implements Dumpable {
 
     private float getLockScreenMediaBlurLevel() {
         float level = (float) Settings.System.getIntForUser(mContext.getContentResolver(),
-                Settings.System.LOCKSCREEN_MEDIA_BLUR, 100,
-                UserHandle.USER_CURRENT) / 4;
+                Settings.System.LOCKSCREEN_MEDIA_BLUR, 25,
+                UserHandle.USER_CURRENT) / 100;
         return level;
     }
 }


### PR DESCRIPTION
11-18 19:33:13.717  1978  3090 E AndroidRuntime: java.lang.RuntimeException: An error occurred while executing doInBackground()
11-18 19:33:13.717  1978  3090 E AndroidRuntime: 	at android.os.AsyncTask$4.done(AsyncTask.java:399)
11-18 19:33:13.717  1978  3090 E AndroidRuntime: 	at java.util.concurrent.FutureTask.finishCompletion(FutureTask.java:383)
11-18 19:33:13.717  1978  3090 E AndroidRuntime: 	at java.util.concurrent.FutureTask.setException(FutureTask.java:252)
11-18 19:33:13.717  1978  3090 E AndroidRuntime: 	at java.util.concurrent.FutureTask.run(FutureTask.java:271)
11-18 19:33:13.717  1978  3090 E AndroidRuntime: 	at android.os.AsyncTask$SerialExecutor$1.run(AsyncTask.java:289)
11-18 19:33:13.717  1978  3090 E AndroidRuntime: 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
11-18 19:33:13.717  1978  3090 E AndroidRuntime: 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
11-18 19:33:13.717  1978  3090 E AndroidRuntime: 	at java.lang.Thread.run(Thread.java:919)
11-18 19:33:13.717  1978  3090 E AndroidRuntime: Caused by: android.renderscript.RSIllegalArgumentException: Radius out of range (0 < r <= 25).
11-18 19:33:13.717  1978  3090 E AndroidRuntime: 	at android.renderscript.ScriptIntrinsicBlur.setRadius(ScriptIntrinsicBlur.java:82)
11-18 19:33:13.717  1978  3090 E AndroidRuntime: 	at com.android.systemui.statusbar.MediaArtworkProcessor.processArtwork(MediaArtworkProcessor.kt:84)
11-18 19:33:13.717  1978  3090 E AndroidRuntime: 	at com.android.systemui.statusbar.NotificationMediaManager.processArtwork(NotificationMediaManager.java:786)
11-18 19:33:13.717  1978  3090 E AndroidRuntime: 	at com.android.systemui.statusbar.NotificationMediaManager.access$700(NotificationMediaManager.java:100)
11-18 19:33:13.717  1978  3090 E AndroidRuntime: 	at com.android.systemui.statusbar.NotificationMediaManager$ProcessArtworkTask.doInBackground(NotificationMediaManager.java:816)
11-18 19:33:13.717  1978  3090 E AndroidRuntime: 	at com.android.systemui.statusbar.NotificationMediaManager$ProcessArtworkTask.doInBackground(NotificationMediaManager.java:797)
11-18 19:33:13.717  1978  3090 E AndroidRuntime: 	at android.os.AsyncTask$3.call(AsyncTask.java:378)
11-18 19:33:13.717  1978  3090 E AndroidRuntime:        at java.util.concurrent.FutureTask.run(FutureTask.java:266)

Signed-off-by: DennySPB <dennyspb@gmail.com>
Change-Id: I8e95875b24a736a9c70fa585898e447aaa09e7ef
Signed-off-by: chandra prakash <scp.thedevil@gmail.com>