### PR TITLE
base: Add support to disable h265 on screenrecorder

### DIFF
--- a/packages/SystemUI/res-revengeos/values/config.xml
+++ b/packages/SystemUI/res-revengeos/values/config.xml
@@ -61,4 +61,7 @@
     <!-- Whether to show biometric help only when failed -->
     <bool name="config_biometricHelpShowOnlyWhenFailed">false</bool>
 
+    <!-- Allow devices to enforce the H265 encoder for screen recordings -->
+    <bool name="config_useNewScreenRecEncoder">true</bool>
+
 </resources>

--- a/packages/SystemUI/src/com/android/systemui/screenrecord/RecordingService.java
+++ b/packages/SystemUI/src/com/android/systemui/screenrecord/RecordingService.java
@@ -255,6 +255,9 @@ public class RecordingService extends Service {
             }
             setTapsVisible(mShowTaps);
 
+            // Check if the device allows to use h265 for lighter recordings
+            boolean useH265 = getResources().getBoolean(R.bool.config_useNewScreenRecEncoder);
+
             // Set up media recorder
             mMediaRecorder = new MediaRecorder();
             if (mAudioSource == 1) {
@@ -272,7 +275,7 @@ public class RecordingService extends Service {
             mWindowManager.getDefaultDisplay().getRealMetrics(metrics);
             int screenWidth = metrics.widthPixels;
             int screenHeight = metrics.heightPixels;
-            mMediaRecorder.setVideoEncoder(MediaRecorder.VideoEncoder.HEVC);
+            mMediaRecorder.setVideoEncoder(useH265 ? MediaRecorder.VideoEncoder.HEVC : MediaRecorder.VideoEncoder.H264);
             mMediaRecorder.setVideoSize(screenWidth, screenHeight);
             mMediaRecorder.setVideoFrameRate(mLowQuality ? LOW_VIDEO_FRAME_RATE : VIDEO_FRAME_RATE);
             mMediaRecorder.setVideoEncodingBitRate(mLowQuality ? LOW_VIDEO_BIT_RATE : VIDEO_BIT_RATE);


### PR DESCRIPTION
Some legacy users might not have the codecs to record/play the final recordings, so let's allow them to
overlay config_useNewScreenRecEncoder in case they need to disable that.

Current set to true, as we want to use it as default.