### PR TITLE
Pull request for r11.0

### DIFF
--- a/core/java/android/hardware/Camera.java
+++ b/core/java/android/hardware/Camera.java
@@ -45,6 +45,7 @@ import android.os.Message;
 import android.os.Process;
 import android.os.RemoteException;
 import android.os.ServiceManager;
+import android.os.SystemProperties;
 import android.renderscript.Allocation;
 import android.renderscript.Element;
 import android.renderscript.RSIllegalArgumentException;
@@ -61,6 +62,7 @@ import com.android.internal.app.IAppOpsService;
 
 import java.io.IOException;
 import java.lang.ref.WeakReference;
+import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -284,6 +286,23 @@ public class Camera {
     private static final int CAMERA_FACE_DETECTION_SW = 1;
 
     /**
+     * @hide
+     */
+    public static boolean shouldExposeAuxCamera() {
+        /**
+         * Force to expose only two cameras
+         * if the package name does not falls in this bucket
+         */
+        String packageName = ActivityThread.currentOpPackageName();
+        List<String> packageList = Arrays.asList(
+                SystemProperties.get("vendor.camera.aux.packagelist", packageName).split(","));
+        List<String> packageBlacklist = Arrays.asList(
+                SystemProperties.get("vendor.camera.aux.packageblacklist", "").split(","));
+
+        return packageList.contains(packageName) && !packageBlacklist.contains(packageName);
+    }
+
+    /**
      * Returns the number of physical cameras available on this device.
      * The return value of this method might change dynamically if the device
      * supports external cameras and an external camera is connected or
@@ -298,7 +317,20 @@ public class Camera {
      * @return total number of accessible camera devices, or 0 if there are no
      *   cameras or an error was encountered enumerating them.
      */
-    public native static int getNumberOfCameras();
+    public static int getNumberOfCameras() {
+        int numberOfCameras = _getNumberOfCameras();
+        if (!shouldExposeAuxCamera() && numberOfCameras > 2) {
+            numberOfCameras = 2;
+        }
+        return numberOfCameras;
+    }
+
+    /**
+     * Returns the number of physical cameras available on this device.
+     *
+     * @hide
+     */
+    public native static int _getNumberOfCameras();
 
     /**
      * Returns the information about a particular camera.
@@ -309,6 +341,9 @@ public class Camera {
      *    low-level failure).
      */
     public static void getCameraInfo(int cameraId, CameraInfo cameraInfo) {
+        if (cameraId >= getNumberOfCameras()) {
+            throw new RuntimeException("Unknown camera ID");
+        }
         _getCameraInfo(cameraId, cameraInfo);
         IBinder b = ServiceManager.getService(Context.AUDIO_SERVICE);
         IAudioService audioService = IAudioService.Stub.asInterface(b);
@@ -581,6 +616,9 @@ public class Camera {
 
     /** used by Camera#open, Camera#open(int) */
     Camera(int cameraId) {
+        if (cameraId >= getNumberOfCameras()) {
+            throw new RuntimeException("Unknown camera ID");
+        }
         int err = cameraInitNormal(cameraId);
         if (checkInitErrors(err)) {
             if (err == -EACCES) {

--- a/core/java/android/hardware/Camera.java
+++ b/core/java/android/hardware/Camera.java
@@ -1879,6 +1879,20 @@ public class Camera {
     }
 
     /**
+     * Send a vendor-specific camera command
+     *
+     * @hide
+     */
+    public final void sendVendorCommand(int cmd, int arg1, int arg2) {
+        if (cmd < 1000) {
+            throw new IllegalArgumentException("Command numbers must be at least 1000");
+        }
+        _sendVendorCommand(cmd, arg1, arg2);
+    }
+
+    private native final void _sendVendorCommand(int cmd, int arg1, int arg2);
+
+    /**
      * Callback interface for zoom changes during a smooth zoom operation.
      *
      * @see #setZoomChangeListener(OnZoomChangeListener)

--- a/core/java/android/hardware/Camera.java
+++ b/core/java/android/hardware/Camera.java
@@ -4759,7 +4759,7 @@ public class Camera {
         // Example string: "(10000,26623),(10000,30000)". Return null if the
         // passing string is null or the size is 0.
         private ArrayList<int[]> splitRange(String str) {
-            if (str == null || str.charAt(0) != '('
+            if (str == null || str.isEmpty() || str.charAt(0) != '('
                     || str.charAt(str.length() - 1) != ')') {
                 Log.e(TAG, "Invalid range list string=" + str);
                 return null;
@@ -4785,7 +4785,7 @@ public class Camera {
         // the passing string is null or the size is 0 or (0,0,0,0,0).
         @UnsupportedAppUsage
         private ArrayList<Area> splitArea(String str) {
-            if (str == null || str.charAt(0) != '('
+            if (str == null || str.isEmpty() || str.charAt(0) != '('
                     || str.charAt(str.length() - 1) != ')') {
                 Log.e(TAG, "Invalid area string=" + str);
                 return null;

--- a/core/java/android/hardware/Camera.java
+++ b/core/java/android/hardware/Camera.java
@@ -4689,6 +4689,7 @@ public class Camera {
             splitter.setString(str);
             int index = 0;
             for (String s : splitter) {
+                s = s.replaceAll("\\s","");
                 output[index++] = Integer.parseInt(s);
             }
         }

--- a/core/java/android/hardware/camera2/CameraManager.java
+++ b/core/java/android/hardware/camera2/CameraManager.java
@@ -23,6 +23,7 @@ import android.annotation.RequiresPermission;
 import android.annotation.SystemService;
 import android.annotation.TestApi;
 import android.content.Context;
+import android.hardware.Camera;
 import android.hardware.CameraInfo;
 import android.hardware.CameraStatus;
 import android.hardware.ICameraService;
@@ -1236,8 +1237,10 @@ public final class CameraManager {
 
         private String[] extractCameraIdListLocked() {
             String[] cameraIds = null;
+            boolean exposeAuxCamera = Camera.shouldExposeAuxCamera();
             int idCount = 0;
             for (int i = 0; i < mDeviceStatus.size(); i++) {
+                if (!exposeAuxCamera && i == 2) break;
                 int status = mDeviceStatus.valueAt(i);
                 if (status == ICameraServiceListener.STATUS_NOT_PRESENT
                         || status == ICameraServiceListener.STATUS_ENUMERATING) continue;
@@ -1717,6 +1720,11 @@ public final class CameraManager {
         }
 
         private void onStatusChangedLocked(int status, String id) {
+            if (!Camera.shouldExposeAuxCamera() && Integer.parseInt(id) >= 2) {
+                Log.w(TAG, "[soar.cts] ignore the status update of camera: " + id);
+                return;
+            }
+
             if (DEBUG) {
                 Log.v(TAG,
                         String.format("Camera id %s has status changed to 0x%x", id, status));

--- a/core/java/android/hardware/camera2/CameraManager.java
+++ b/core/java/android/hardware/camera2/CameraManager.java
@@ -1499,6 +1499,26 @@ public final class CameraManager {
                     throw new IllegalArgumentException("cameraId was null");
                 }
 
+                /* Force to expose only two cameras
+                 * if the package name does not falls in this bucket
+                 */
+                boolean exposeAuxCamera = false;
+                String packageName = ActivityThread.currentOpPackageName();
+                String packageList = SystemProperties.get("vendor.camera.aux.packagelist");
+                if (packageList.length() > 0) {
+                    TextUtils.StringSplitter splitter = new TextUtils.SimpleStringSplitter(',');
+                    splitter.setString(packageList);
+                    for (String str : splitter) {
+                        if (packageName.equals(str)) {
+                            exposeAuxCamera = true;
+                            break;
+                        }
+                    }
+                }
+                if (exposeAuxCamera == false && (Integer.parseInt(cameraId) >= 2)) {
+                    throw new IllegalArgumentException("invalid cameraId");
+                }
+
                 ICameraService cameraService = getCameraService();
                 if (cameraService == null) {
                     throw new CameraAccessException(CameraAccessException.CAMERA_DISCONNECTED,
@@ -1827,6 +1847,31 @@ public final class CameraManager {
                 Log.v(TAG,
                         String.format("Camera id %s has torch status changed to 0x%x", id, status));
             }
+
+            /* Force to ignore the aux or composite camera torch status update
+             * if the package name does not falls in this bucket
+             */
+            boolean exposeMonoCamera = false;
+            String packageName = ActivityThread.currentOpPackageName();
+            String packageList = SystemProperties.get("vendor.camera.aux.packagelist");
+            if (packageList.length() > 0) {
+                TextUtils.StringSplitter splitter = new TextUtils.SimpleStringSplitter(',');
+                splitter.setString(packageList);
+                for (String str : splitter) {
+                    if (packageName.equals(str)) {
+                        exposeMonoCamera = true;
+                        break;
+                    }
+                }
+            }
+
+            if (exposeMonoCamera == false) {
+                if (Integer.parseInt(id) >= 2) {
+                    Log.w(TAG, "ignore the torch status update of camera: " + id);
+                    return;
+                }
+            }
+
 
             if (!validTorchStatus(status)) {
                 Log.e(TAG, String.format("Ignoring invalid device %s torch status 0x%x", id,

--- a/core/java/android/hardware/camera2/CameraManager.java
+++ b/core/java/android/hardware/camera2/CameraManager.java
@@ -1505,19 +1505,7 @@ public final class CameraManager {
                 /* Force to expose only two cameras
                  * if the package name does not falls in this bucket
                  */
-                boolean exposeAuxCamera = false;
-                String packageName = ActivityThread.currentOpPackageName();
-                String packageList = SystemProperties.get("vendor.camera.aux.packagelist");
-                if (packageList.length() > 0) {
-                    TextUtils.StringSplitter splitter = new TextUtils.SimpleStringSplitter(',');
-                    splitter.setString(packageList);
-                    for (String str : splitter) {
-                        if (packageName.equals(str)) {
-                            exposeAuxCamera = true;
-                            break;
-                        }
-                    }
-                }
+                boolean exposeAuxCamera = Camera.shouldExposeAuxCamera();
                 if (exposeAuxCamera == false && (Integer.parseInt(cameraId) >= 2)) {
                     throw new IllegalArgumentException("invalid cameraId");
                 }
@@ -1859,25 +1847,10 @@ public final class CameraManager {
             /* Force to ignore the aux or composite camera torch status update
              * if the package name does not falls in this bucket
              */
-            boolean exposeMonoCamera = false;
-            String packageName = ActivityThread.currentOpPackageName();
-            String packageList = SystemProperties.get("vendor.camera.aux.packagelist");
-            if (packageList.length() > 0) {
-                TextUtils.StringSplitter splitter = new TextUtils.SimpleStringSplitter(',');
-                splitter.setString(packageList);
-                for (String str : splitter) {
-                    if (packageName.equals(str)) {
-                        exposeMonoCamera = true;
-                        break;
-                    }
-                }
-            }
-
-            if (exposeMonoCamera == false) {
-                if (Integer.parseInt(id) >= 2) {
-                    Log.w(TAG, "ignore the torch status update of camera: " + id);
-                    return;
-                }
+            boolean exposeAuxCamera = Camera.shouldExposeAuxCamera();
+            if (!exposeAuxCamera == false && Integer.parseInt(id) >= 2) {
+                Log.w(TAG, "ignore the torch status update of camera: " + id);
+                return;
             }
 
 

--- a/core/java/android/hardware/camera2/CameraManager.java
+++ b/core/java/android/hardware/camera2/CameraManager.java
@@ -1249,6 +1249,7 @@ public final class CameraManager {
             cameraIds = new String[idCount];
             idCount = 0;
             for (int i = 0; i < mDeviceStatus.size(); i++) {
+                if (!exposeAuxCamera && i == 2) break;
                 int status = mDeviceStatus.valueAt(i);
                 if (status == ICameraServiceListener.STATUS_NOT_PRESENT
                         || status == ICameraServiceListener.STATUS_ENUMERATING) continue;

--- a/core/java/android/hardware/camera2/impl/CameraCaptureSessionImpl.java
+++ b/core/java/android/hardware/camera2/impl/CameraCaptureSessionImpl.java
@@ -221,7 +221,8 @@ public class CameraCaptureSessionImpl extends CameraCaptureSession
         } else if (request.isReprocess() && !isReprocessable()) {
             throw new IllegalArgumentException("this capture session cannot handle reprocess " +
                     "requests");
-        } else if (request.isReprocess() && request.getReprocessableSessionId() != mId) {
+        } else if (!mDeviceImpl.isPrivilegedApp() &&
+                request.isReprocess() && request.getReprocessableSessionId() != mId) {
             throw new IllegalArgumentException("capture request was created for another session");
         }
     }

--- a/core/java/android/hardware/camera2/impl/CameraDeviceImpl.java
+++ b/core/java/android/hardware/camera2/impl/CameraDeviceImpl.java
@@ -16,10 +16,13 @@
 
 package android.hardware.camera2.impl;
 
+import static android.hardware.camera2.CameraAccessException.CAMERA_IN_USE;
 import static com.android.internal.util.function.pooled.PooledLambda.obtainRunnable;
 
 import android.annotation.NonNull;
 import android.hardware.ICameraService;
+import android.app.ActivityThread;
+import android.graphics.ImageFormat;
 import android.hardware.camera2.CameraAccessException;
 import android.hardware.camera2.CameraCaptureSession;
 import android.hardware.camera2.CameraCharacteristics;
@@ -45,6 +48,8 @@ import android.os.IBinder;
 import android.os.Looper;
 import android.os.RemoteException;
 import android.os.ServiceSpecificException;
+import android.os.SystemProperties;
+import android.text.TextUtils;
 import android.util.Log;
 import android.util.Range;
 import android.util.Size;
@@ -129,6 +134,7 @@ public class CameraDeviceImpl extends CameraDevice
     private int mNextSessionId = 0;
 
     private final int mAppTargetSdkVersion;
+    private boolean mIsPrivilegedApp = false;
 
     private ExecutorService mOfflineSwitchService;
     private CameraOfflineSessionImpl mOfflineSessionImpl;
@@ -274,6 +280,7 @@ public class CameraDeviceImpl extends CameraDevice
         } else {
             mTotalPartialCount = partialCount;
         }
+        mIsPrivilegedApp = checkPrivilegedAppList();
     }
 
     public CameraDeviceCallbacks getCallbacks() {
@@ -1336,10 +1343,40 @@ public class CameraDeviceImpl extends CameraDevice
         }
     }
 
+    private boolean checkPrivilegedAppList() {
+        String packageName = ActivityThread.currentOpPackageName();
+        String packageList = SystemProperties.get("persist.vendor.camera.privapp.list");
+
+        if (packageList.length() > 0) {
+            TextUtils.StringSplitter splitter = new TextUtils.SimpleStringSplitter(',');
+            splitter.setString(packageList);
+            for (String str : splitter) {
+                if (packageName.equals(str)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    public boolean isPrivilegedApp() {
+        return mIsPrivilegedApp;
+    }
+
     private void checkInputConfiguration(InputConfiguration inputConfig) {
         if (inputConfig != null) {
             StreamConfigurationMap configMap = mCharacteristics.get(
                     CameraCharacteristics.SCALER_STREAM_CONFIGURATION_MAP);
+
+            /*
+             * don't check input format and size,
+             * if the package name is in the white list
+             */
+            if (isPrivilegedApp()) {
+                Log.w(TAG, "ignore input format/size check for white listed app");
+                return;
+            }
 
             int[] inputFormats = configMap.getInputFormats();
             boolean validFormat = false;

--- a/core/java/android/hardware/camera2/utils/SurfaceUtils.java
+++ b/core/java/android/hardware/camera2/utils/SurfaceUtils.java
@@ -30,6 +30,11 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 
+import android.app.ActivityThread;
+import android.os.SystemProperties;
+import android.text.TextUtils;
+
+
 /**
  * Various Surface utilities.
  */
@@ -157,7 +162,13 @@ public class SurfaceUtils {
                     + " the size must be 1 or 2");
         }
 
+        if (isPrivilegedApp()) {
+            //skip checks for privileged apps
+            return;
+        }
+
         List<Size> highSpeedSizes = null;
+
         if (fpsRange == null) {
             highSpeedSizes = Arrays.asList(config.getHighSpeedVideoSizes());
         } else {
@@ -209,4 +220,20 @@ public class SurfaceUtils {
         }
     }
 
+    private static boolean isPrivilegedApp() {
+        String packageName = ActivityThread.currentOpPackageName();
+        String packageList = SystemProperties.get("persist.camera.privapp.list");
+
+        if (packageList.length() > 0) {
+            TextUtils.StringSplitter splitter = new TextUtils.SimpleStringSplitter(',');
+            splitter.setString(packageList);
+            for (String str : splitter) {
+                if (packageName.equals(str)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
 }

--- a/core/jni/android_hardware_Camera.cpp
+++ b/core/jni/android_hardware_Camera.cpp
@@ -1129,7 +1129,7 @@ static int32_t android_hardware_Camera_getAudioRestriction(
 //-------------------------------------------------
 
 static const JNINativeMethod camMethods[] = {
-  { "getNumberOfCameras",
+  { "_getNumberOfCameras",
     "()I",
     (void *)android_hardware_Camera_getNumberOfCameras },
   { "_getCameraInfo",

--- a/core/jni/android_hardware_Camera.cpp
+++ b/core/jni/android_hardware_Camera.cpp
@@ -1126,6 +1126,18 @@ static int32_t android_hardware_Camera_getAudioRestriction(
     return ret;
 }
 
+static void android_hardware_Camera_sendVendorCommand(JNIEnv *env, jobject thiz,
+        jint cmd, jint arg1, jint arg2)
+{
+    ALOGV("sendVendorCommand");
+    sp<Camera> camera = get_native_camera(env, thiz, NULL);
+    if (camera == 0) return;
+
+    if (camera->sendCommand(cmd, arg1, arg2) != NO_ERROR) {
+        jniThrowRuntimeException(env, "sending vendor command failed");
+    }
+}
+
 //-------------------------------------------------
 
 static const JNINativeMethod camMethods[] = {
@@ -1228,6 +1240,9 @@ static const JNINativeMethod camMethods[] = {
   { "getAudioRestriction",
     "()I",
     (void *)android_hardware_Camera_getAudioRestriction},
+  { "_sendVendorCommand",
+    "(III)V",
+    (void *)android_hardware_Camera_sendVendorCommand },
 };
 
 struct field {


### PR DESCRIPTION
## camera: Skip HFR checks for privileged apps.

Issue: HAL3 supports HFR only if its greater than or equal
       to 120fps.

Fix: Skip the checks to allow HFR 60 and 90 fps in HAL3 for
     specific apps.
     The following property need to be set to allow these
     HFR configurations :
     adb shell setprop persist.camera.privapp.list <pack1,pack2,etc>

Change-Id: I5f3bc94bea60dbe03284de39cd4280f67df8b015
CRs-Fixed: 2258892
Signed-off-by: DennySPB <dennyspb@gmail.com>
Signed-off-by: DennySPb <dennyspb@gmail.com>

## Camera: Ignore torch status update for aux or compsite camera

Issue:
  We only expose aux and composite camera ids to whitelist app,
  but don't check the whitelist in torch status update.
  So for apps not in whitelist like CTS,
  they might receive extra unexpected torch status update,
  from aux and composite camera, which could cause CTS failure.

Fix:
  Also ignore torch status update, if app not in whitelist.
  It can fixe CTS issues in FlashlightTest.java.

CRs-Fixed: 2033688
Change-Id: I308bccfc027017b590f9f91089d644f7d8a206ff
Signed-off-by: DennySPB <dennyspb@gmail.com>
Signed-off-by: DennySPb <dennyspb@gmail.com>

## Camera: Skip stream size check for whitelisted apps..

Issue:
For quadracfa capture, Blob/YUV output streams need to be
configured with custom dimensions which will not be
available in advertised stream configurations map.

Fix:
Skip the stream size check for whitelisted apps to allow
configuration of streams with custom dimensions.

Also, additionally, remove session id check so that
buffers from one session can be passed on to another
session for reprocess.

Setprop to be used:
adb shell setprop persist.vendor.camera.privapp.list <pack1,pack2>

CRs-Fixed: 2075934
Change-Id: Ie9c950fdc4e1675d19c38630d7063ac9d7c9d5b1
Signed-off-by: DennySPB <dennyspb@gmail.com>
Signed-off-by: DennySPb <dennyspb@gmail.com>

## camera: Support exposing aux camera to apps

Original change:

Author: Sauhard Pande <sauhardp@codeaurora.org>
Date:   Thu Jul 21 18:23:21 2016 -0700

    Camera: Expose Aux camera to apps present in the whitelist

    Issue:
    3rd party apk cannot handle additional aux camera and may cause crash,
    Mono camera doesnt support all capabilities of HAL3 causing CTS issue.

    Fix:
    1. Expose aux camera to apps present in the whitelist
    2. ignore the availabe/unavailable status update for aux camera
    3. returning exception for open request for bad cameraid

    Change-Id: I15910154c6df205e6d4e00bfad30a00c9e3d5bee
    CRs-Fixed: 1086937

---------------------------------------------------------------------------

Forward-ported to Q and squashed with the following changes:

Author: Rashed Abdel-Tawab <rashed@linux.com>
Date:   Sat Mar 24 13:20:52 2018 -0400

    camera: Check if aux camera whitelist is set before restricting cameras

    Some devices have a fully featured 3rd camera and adding 20+ camera apps
    to the whitelist is impossible due to the string length limit on
    systemprops. Add a check to see if the prop is even set, and if not,
    check if the blacklist property is set and mark those apps to hide the
    3rd camera from. If a package is not part of the blacklist, just restore
    the original behaviour and expose all the cameras to the app.

    Change-Id: I6c3b33c077e8710c73b5d0fa28e1b017d6c43a58

Author: Paul Keith <javelinanddart@gmail.com>
Date:   Fri Feb 8 08:42:33 2019 -0600

    Camera: Simplify code for Aux/Mono white and black lists

    Change-Id: I20c5454385d4d830a9a4d61926807a7eb1407c95

Change-Id: I15910154c6df205e6d4e00bfad30a00c9e3d5bee
Signed-off-by: DennySPb <dennyspb@gmail.com>

## fixup - Camera: Ignore torch status update for aux or compsite camera

* Import was removed on 6f1eea15f5e6f3e5e6d152f10d39c9fbfc2b5140
* New method introduced on 84ef96a7759020e011c7fa8d1d22a97fa64aaaa6

Change-Id: I47db6abb67ee8c8185574de462637fee22e71c9e
Signed-off-by: DennySPb <dennyspb@gmail.com>

## Allow sending vendor- or device-specific commands to the camera HAL.

Change-Id: I2aaa9e526b6f1a35d45e96b6d23e3db972d82733
Signed-off-by: Joe Maples <joe@frap129.org>
Signed-off-by: DennySPb <dennyspb@gmail.com>

## [fixup] camera: Support exposing aux camera to apps

Signed-off-by: DennySPb <dennyspb@gmail.com>
Change-Id: I4e50d8ad67e177e9ffefb8be72ae54498a84325c

## Guard in short-circuit evaluations for stringSplit methods.

* splitRange function should also check if string is empty instead of
  just checking for null, as a faulty camera can return
  an empty RangeLength string.
* See (stripped) logcat: http://pastebin.com/kVV3ZJhz

Change-Id: Icbb8f12d1c2511366856889edc9b2060b764f2d0
Signed-off-by: Joe Maples <joe@frap129.org>
Signed-off-by: DennySPb <dennyspb@gmail.com>

## Camera: Don't throw exceptions when value pairs have spaces in them

"(1,2)" worked, "(1, 2)" crapped out. Fix it.

Change-Id: I71262909280f88d930898a2bcf37d379add4fdea
Signed-off-by: Joe Maples <joe@frap129.org>
Signed-off-by: DennySPb <dennyspb@gmail.com>