### PR TITLE
VibratorService: implement OnePlus proprietary vibrator format [squashed]

### DIFF
--- a/core/res/res/values/config.xml
+++ b/core/res/res/values/config.xml
@@ -4384,4 +4384,9 @@
     <!-- The list of components which should be forced to be enabled. -->
     <string-array name="config_forceEnabledComponents" translatable="false">
     </string-array>
+
+    <!-- OnePlus uses a proprietary vibrator hal to utilize the new powerful motor since the
+         OnePlus 7 Pro. This HAL expects a different format for the data instead of the usual (ms)
+         timing(the duration which the vibrator is expected to vibrate for). -->
+    <bool name="config_hasOnePlusHapticMotor">false</bool>
 </resources>

--- a/core/res/res/values/symbols.xml
+++ b/core/res/res/values/symbols.xml
@@ -4056,4 +4056,7 @@
   <java-symbol type="array" name="config_deviceDisabledComponents" />
   <java-symbol type="array" name="config_globallyDisabledComponents" />
   <java-symbol type="array" name="config_forceEnabledComponents" />
+
+  <!-- Device has OnePlus haptic motor -->
+  <java-symbol type="bool" name="config_hasOnePlusHapticMotor" />
 </resources>


### PR DESCRIPTION
OnePlus proprietary vibrator hal doesn't work the way the open-source one does.

Add an encoding function to map the parameter(time in ms) to OnePlus HAL
friendly format.

Needs config_hasOnePlusHapticMotor=true.

@neobuddy89: Removed modification to AOSP patterns.
@idoybh: Adapted to A11

Change-Id: I393588fdc85a7f7f9d35a96f601b09f71e625370