### PR TITLE
Pull request for r11.0

### DIFF
--- a/core/res/res/values/config.xml
+++ b/core/res/res/values/config.xml
@@ -4391,4 +4391,7 @@
          OnePlus 7 Pro. This HAL expects a different format for the data instead of the usual (ms)
          timing(the duration which the vibrator is expected to vibrate for). -->
     <bool name="config_hasOnePlusHapticMotor">false</bool>
+
+    <!-- FOD icon dim-->
+    <bool name="config_targetUsesInKernelDimming">false</bool>
 </resources>

--- a/core/res/res/values/symbols.xml
+++ b/core/res/res/values/symbols.xml
@@ -4059,4 +4059,10 @@
 
   <!-- Device has OnePlus haptic motor -->
   <java-symbol type="bool" name="config_hasOnePlusHapticMotor" />
+
+  <!-- Whether to show a custom view for FOD -->
+  <java-symbol type="bool" name="config_needCustomFODView" />
+
+  <!-- FOD icon dimming -->
+  <java-symbol type="bool" name="config_targetUsesInKernelDimming" />
 </resources>

--- a/packages/SystemUI/src/com/android/systemui/biometrics/FODCircleView.java
+++ b/packages/SystemUI/src/com/android/systemui/biometrics/FODCircleView.java
@@ -147,6 +147,7 @@ public class FODCircleView extends ImageView {
                 mBurnInProtectionTimer.schedule(new BurnInProtectionTask(), 0, 60 * 1000);
             } else if (mBurnInProtectionTimer != null) {
                 mBurnInProtectionTimer.cancel();
+                updatePosition();
             }
         }
 

--- a/packages/SystemUI/src/com/android/systemui/biometrics/FODCircleView.java
+++ b/packages/SystemUI/src/com/android/systemui/biometrics/FODCircleView.java
@@ -16,6 +16,9 @@
 
 package com.android.systemui.biometrics;
 
+import android.animation.Animator;
+import android.animation.AnimatorListenerAdapter;
+import android.animation.ValueAnimator;
 import android.app.admin.DevicePolicyManager;
 import android.content.Context;
 import android.content.res.Configuration;
@@ -101,6 +104,7 @@ public class FODCircleView extends ImageView implements TunerService.Tunable {
     private boolean mIsBouncer;
     private boolean mIsDreaming;
     private boolean mIsCircleShowing;
+    private boolean mIsAnimating = false;
 
     private Handler mHandler;
 
@@ -257,7 +261,7 @@ public class FODCircleView extends ImageView implements TunerService.Tunable {
     @Override
     public void onTuningChanged(String key, String newValue) {
         mCurrentBrightness = newValue != null ? Integer.parseInt(newValue) : 0;
-        updateIconDim();
+        updateIconDim(false);
     }
 
     private int interpolate(int i, int i2, int i3, int i4, int i5) {
@@ -286,9 +290,31 @@ public class FODCircleView extends ImageView implements TunerService.Tunable {
         return interpolate(mCurrentBrightness, iArr[i2][0], iArr[i][0], iArr[i2][1], iArr[i][1]);
     }
 
-    public void updateIconDim() {
+    public void updateIconDim(boolean animate) {
         if (!mIsCircleShowing && mTargetUsesInKernelDimming) {
-            setColorFilter(Color.argb(getDimAlpha(), 0, 0, 0), PorterDuff.Mode.SRC_ATOP);
+            if (animate && !mIsAnimating) {
+                ValueAnimator anim = new ValueAnimator();
+                anim.setIntValues(0, getDimAlpha());
+                anim.addUpdateListener(new ValueAnimator.AnimatorUpdateListener() {
+                    @Override
+                    public void onAnimationUpdate(ValueAnimator valueAnimator) {
+                        int progress = (Integer) valueAnimator.getAnimatedValue();
+                        setColorFilter(Color.argb(progress, 0, 0, 0),
+                                PorterDuff.Mode.SRC_ATOP);
+                    }
+                });
+                anim.addListener(new AnimatorListenerAdapter() {
+                    @Override
+                    public void onAnimationEnd(Animator animation) {
+                        mIsAnimating = false;
+                    }
+                });
+                anim.setDuration(1000);
+                mIsAnimating = true;
+                anim.start();
+            } else if (!mIsAnimating) {
+                setColorFilter(Color.argb(getDimAlpha(), 0, 0, 0), PorterDuff.Mode.SRC_ATOP);
+            }
         } else {
             setColorFilter(Color.argb(0, 0, 0, 0), PorterDuff.Mode.SRC_ATOP);
         }
@@ -389,7 +415,7 @@ public class FODCircleView extends ImageView implements TunerService.Tunable {
         dispatchPress();
 
         setImageDrawable(null);
-        updateIconDim();
+        updateIconDim(false);
         invalidate();
     }
 
@@ -510,6 +536,7 @@ public class FODCircleView extends ImageView implements TunerService.Tunable {
             if (mPressedView.getParent() != null) {
                 mWindowManager.removeView(mPressedView);
             }
+            updateIconDim(true);
         }
     }
 

--- a/packages/SystemUI/src/com/android/systemui/biometrics/FODCircleView.java
+++ b/packages/SystemUI/src/com/android/systemui/biometrics/FODCircleView.java
@@ -29,6 +29,8 @@ import android.graphics.Paint;
 import android.graphics.PixelFormat;
 import android.graphics.Point;
 import android.graphics.PorterDuff;
+import android.graphics.PorterDuffXfermode;
+import android.net.Uri;
 import android.os.Handler;
 import android.os.Looper;
 import android.os.RemoteException;
@@ -323,6 +325,7 @@ public class FODCircleView extends ImageView implements TunerService.Tunable {
     @Override
     protected void onDraw(Canvas canvas) {
         if (!mIsCircleShowing) {
+            mPaintFingerprintBackground.setXfermode(new PorterDuffXfermode(PorterDuff.Mode.SRC_IN));
             canvas.drawCircle(mSize / 2, mSize / 2, mSize / 2.0f, mPaintFingerprintBackground);
         }
         super.onDraw(canvas);

--- a/packages/SystemUI/src/com/android/systemui/biometrics/FODCircleView.java
+++ b/packages/SystemUI/src/com/android/systemui/biometrics/FODCircleView.java
@@ -230,7 +230,8 @@ public class FODCircleView extends ImageView implements TunerService.Tunable {
         mParams.packageName = "android";
         mParams.type = WindowManager.LayoutParams.TYPE_DISPLAY_OVERLAY;
         mParams.flags = WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE |
-                WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN;
+                WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN |
+                WindowManager.LayoutParams.FLAG_HARDWARE_ACCELERATED;
         mParams.gravity = Gravity.TOP | Gravity.LEFT;
 
         mPressedParams.copyFrom(mParams);

--- a/packages/SystemUI/src/com/android/systemui/biometrics/FODCircleView.java
+++ b/packages/SystemUI/src/com/android/systemui/biometrics/FODCircleView.java
@@ -47,6 +47,7 @@ import com.android.internal.widget.LockPatternUtils;
 import com.android.keyguard.KeyguardSecurityModel.SecurityMode;
 import com.android.keyguard.KeyguardUpdateMonitor;
 import com.android.keyguard.KeyguardUpdateMonitorCallback;
+import com.android.settingslib.utils.ThreadUtils;
 import com.android.systemui.Dependency;
 import com.android.systemui.R;
 import com.android.systemui.tuner.TunerService;
@@ -414,8 +415,10 @@ public class FODCircleView extends ImageView implements TunerService.Tunable {
 
         setKeepScreenOn(true);
 
-        setDim(true);
-        dispatchPress();
+	setDim(true);
+        ThreadUtils.postOnBackgroundThread(() -> {
+            dispatchPress();
+        });
 
         setImageDrawable(null);
         updateIconDim(false);
@@ -428,7 +431,9 @@ public class FODCircleView extends ImageView implements TunerService.Tunable {
         setImageResource(R.drawable.fod_icon_default);
         invalidate();
 
-        dispatchRelease();
+        ThreadUtils.postOnBackgroundThread(() -> {
+            dispatchRelease();
+        });
         setDim(false);
 
         setKeepScreenOn(false);
@@ -448,8 +453,9 @@ public class FODCircleView extends ImageView implements TunerService.Tunable {
         updatePosition();
 
         Dependency.get(TunerService.class).addTunable(this, SCREEN_BRIGHTNESS);
-        
-	dispatchShow();
+        ThreadUtils.postOnBackgroundThread(() -> {
+            dispatchShow();
+        });
         setVisibility(View.VISIBLE);
     }
 
@@ -457,7 +463,9 @@ public class FODCircleView extends ImageView implements TunerService.Tunable {
         setVisibility(View.GONE);
         Dependency.get(TunerService.class).removeTunable(this);
         hideCircle();
-        dispatchHide();
+        ThreadUtils.postOnBackgroundThread(() -> {
+            dispatchHide();
+        });
     }
 
     private void updateAlpha() {

--- a/packages/SystemUI/src/com/android/systemui/biometrics/FODCircleView.java
+++ b/packages/SystemUI/src/com/android/systemui/biometrics/FODCircleView.java
@@ -350,6 +350,8 @@ public class FODCircleView extends ImageView {
 
         updatePosition();
 
+        updatePosition();
+
         dispatchShow();
         setVisibility(View.VISIBLE);
     }

--- a/packages/SystemUI/src/com/android/systemui/biometrics/FODCircleView.java
+++ b/packages/SystemUI/src/com/android/systemui/biometrics/FODCircleView.java
@@ -20,9 +20,11 @@ import android.animation.Animator;
 import android.animation.AnimatorListenerAdapter;
 import android.animation.ValueAnimator;
 import android.app.admin.DevicePolicyManager;
+import android.content.ContentResolver;
 import android.content.Context;
 import android.content.res.Configuration;
 import android.content.res.Resources;
+import android.database.ContentObserver;
 import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Paint;
@@ -34,6 +36,7 @@ import android.net.Uri;
 import android.os.Handler;
 import android.os.Looper;
 import android.os.RemoteException;
+import android.os.UserHandle;
 import android.provider.Settings;
 import android.view.Display;
 import android.view.Gravity;
@@ -50,7 +53,6 @@ import com.android.keyguard.KeyguardUpdateMonitorCallback;
 import com.android.settingslib.utils.ThreadUtils;
 import com.android.systemui.Dependency;
 import com.android.systemui.R;
-import com.android.systemui.tuner.TunerService;
 
 import vendor.lineage.biometrics.fingerprint.inscreen.V1_0.IFingerprintInscreen;
 import vendor.lineage.biometrics.fingerprint.inscreen.V1_0.IFingerprintInscreenCallback;
@@ -59,9 +61,9 @@ import java.util.NoSuchElementException;
 import java.util.Timer;
 import java.util.TimerTask;
 
-public class FODCircleView extends ImageView implements TunerService.Tunable {
+public class FODCircleView extends ImageView {
     private static final int FADE_ANIM_DURATION = 250;
-    private final String SCREEN_BRIGHTNESS = "system:" + Settings.System.SCREEN_BRIGHTNESS;
+    private final String SCREEN_BRIGHTNESS = Settings.System.SCREEN_BRIGHTNESS;
     private final int[][] BRIGHTNESS_ALPHA_ARRAY = {
         new int[]{0, 255},
         new int[]{1, 224},
@@ -96,6 +98,7 @@ public class FODCircleView extends ImageView implements TunerService.Tunable {
     private final WindowManager mWindowManager;
 
     private IFingerprintInscreen mFingerprintInscreenDaemon;
+    private Context mContext;
 
     private int mCurrentBrightness;
     private int mDreamingOffsetX;
@@ -182,8 +185,40 @@ public class FODCircleView extends ImageView implements TunerService.Tunable {
         }
     };
 
+    private class CustomSettingsObserver extends ContentObserver {
+        CustomSettingsObserver(Handler handler) {
+            super(handler);
+        }
+
+        void observe() {
+            ContentResolver resolver = mContext.getContentResolver();
+            resolver.registerContentObserver(Settings.System.getUriFor(
+                    SCREEN_BRIGHTNESS), false, this, UserHandle.USER_ALL);
+        }
+
+        void unobserve() {
+            mContext.getContentResolver().unregisterContentObserver(this);
+        }
+
+        @Override
+        public void onChange(boolean selfChange, Uri uri) {
+            // if (uri.equals(Settings.System.getUriFor(SCREEN_BRIGHTNESS))) {
+            update();
+            // }
+        }
+
+        void update() {
+            mCurrentBrightness = Settings.System.getInt(
+                    mContext.getContentResolver(), SCREEN_BRIGHTNESS, 100);
+            updateIconDim(false);
+        }
+    }
+
+    private CustomSettingsObserver mCustomSettingsObserver;
+
     public FODCircleView(Context context) {
         super(context);
+        mContext = context;
 
         setScaleType(ScaleType.CENTER);
 
@@ -223,6 +258,8 @@ public class FODCircleView extends ImageView implements TunerService.Tunable {
 
         mHandler = new Handler(Looper.getMainLooper());
 
+        mCustomSettingsObserver = new CustomSettingsObserver(mHandler);
+
         mParams.height = mSize;
         mParams.width = mSize;
         mParams.format = PixelFormat.TRANSLUCENT;
@@ -260,12 +297,6 @@ public class FODCircleView extends ImageView implements TunerService.Tunable {
 
         mUpdateMonitor = Dependency.get(KeyguardUpdateMonitor.class);
         mUpdateMonitor.registerCallback(mMonitorCallback);
-    }
-
-    @Override
-    public void onTuningChanged(String key, String newValue) {
-        mCurrentBrightness = newValue != null ? Integer.parseInt(newValue) : 0;
-        updateIconDim(false);
     }
 
     private int interpolate(int i, int i2, int i3, int i4, int i5) {
@@ -452,8 +483,9 @@ public class FODCircleView extends ImageView implements TunerService.Tunable {
         }
 
         updatePosition();
+        mCustomSettingsObserver.observe();
+        mCustomSettingsObserver.update();
 
-        Dependency.get(TunerService.class).addTunable(this, SCREEN_BRIGHTNESS);
         ThreadUtils.postOnBackgroundThread(() -> {
             dispatchShow();
         });
@@ -462,7 +494,7 @@ public class FODCircleView extends ImageView implements TunerService.Tunable {
 
     public void hide() {
         setVisibility(View.GONE);
-        Dependency.get(TunerService.class).removeTunable(this);
+        mCustomSettingsObserver.unobserve();
         hideCircle();
         ThreadUtils.postOnBackgroundThread(() -> {
             dispatchHide();

--- a/packages/SystemUI/src/com/android/systemui/biometrics/FODCircleView.java
+++ b/packages/SystemUI/src/com/android/systemui/biometrics/FODCircleView.java
@@ -25,6 +25,7 @@ import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.PixelFormat;
 import android.graphics.Point;
+import android.graphics.PorterDuff;
 import android.os.Handler;
 import android.os.Looper;
 import android.os.RemoteException;
@@ -43,6 +44,7 @@ import com.android.keyguard.KeyguardUpdateMonitor;
 import com.android.keyguard.KeyguardUpdateMonitorCallback;
 import com.android.systemui.Dependency;
 import com.android.systemui.R;
+import com.android.systemui.tuner.TunerService;
 
 import vendor.lineage.biometrics.fingerprint.inscreen.V1_0.IFingerprintInscreen;
 import vendor.lineage.biometrics.fingerprint.inscreen.V1_0.IFingerprintInscreenCallback;
@@ -51,13 +53,36 @@ import java.util.NoSuchElementException;
 import java.util.Timer;
 import java.util.TimerTask;
 
-public class FODCircleView extends ImageView {
+public class FODCircleView extends ImageView implements TunerService.Tunable {
+    private static final int FADE_ANIM_DURATION = 250;
+    private final String SCREEN_BRIGHTNESS = "system:" + Settings.System.SCREEN_BRIGHTNESS;
+    private final int[][] BRIGHTNESS_ALPHA_ARRAY = {
+        new int[]{0, 255},
+        new int[]{1, 224},
+        new int[]{2, 213},
+        new int[]{3, 211},
+        new int[]{4, 208},
+        new int[]{5, 206},
+        new int[]{6, 203},
+        new int[]{8, 200},
+        new int[]{10, 196},
+        new int[]{15, 186},
+        new int[]{20, 176},
+        new int[]{30, 160},
+        new int[]{45, 139},
+        new int[]{70, 114},
+        new int[]{100, 90},
+        new int[]{150, 56},
+        new int[]{227, 14},
+        new int[]{255, 0}
+    };
     private final int mPositionX;
     private final int mPositionY;
     private final int mSize;
     private final int mDreamingMaxOffset;
     private final int mNavigationBarSize;
     private final boolean mShouldBoostBrightness;
+    private final boolean mTargetUsesInKernelDimming;
     private final Paint mPaintFingerprintBackground = new Paint();
     private final Paint mPaintFingerprint = new Paint();
     private final WindowManager.LayoutParams mParams = new WindowManager.LayoutParams();
@@ -66,6 +91,7 @@ public class FODCircleView extends ImageView {
 
     private IFingerprintInscreen mFingerprintInscreenDaemon;
 
+    private int mCurrentBrightness;
     private int mDreamingOffsetX;
     private int mDreamingOffsetY;
 
@@ -176,6 +202,7 @@ public class FODCircleView extends ImageView {
 
         mColorBackground = res.getColor(R.color.config_fodColorBackground);
         mPaintFingerprintBackground.setColor(mColorBackground);
+        mTargetUsesInKernelDimming = res.getBoolean(com.android.internal.R.bool.config_targetUsesInKernelDimming);
         mPaintFingerprintBackground.setAntiAlias(true);
 
         mMinBottomMargin = res.getDimensionPixelSize(
@@ -225,6 +252,46 @@ public class FODCircleView extends ImageView {
 
         mUpdateMonitor = Dependency.get(KeyguardUpdateMonitor.class);
         mUpdateMonitor.registerCallback(mMonitorCallback);
+    }
+
+    @Override
+    public void onTuningChanged(String key, String newValue) {
+        mCurrentBrightness = newValue != null ? Integer.parseInt(newValue) : 0;
+        updateIconDim();
+    }
+
+    private int interpolate(int i, int i2, int i3, int i4, int i5) {
+        int i6 = i5 - i4;
+        int i7 = i - i2;
+        int i8 = ((i6 * 2) * i7) / (i3 - i2);
+        int i9 = i8 / 2;
+        int i10 = i2 - i3;
+        return i4 + i9 + (i8 % 2) + ((i10 == 0 || i6 == 0) ? 0 : (((i7 * 2) * (i - i3)) / i6) / i10);
+    }
+
+    private int getDimAlpha() {
+        int length = BRIGHTNESS_ALPHA_ARRAY.length;
+        int i = 0;
+        while (i < length && BRIGHTNESS_ALPHA_ARRAY[i][0] < mCurrentBrightness) {
+            i++;
+        }
+        if (i == 0) {
+            return BRIGHTNESS_ALPHA_ARRAY[0][1];
+        }
+        if (i == length) {
+            return BRIGHTNESS_ALPHA_ARRAY[length - 1][1];
+        }
+        int[][] iArr = BRIGHTNESS_ALPHA_ARRAY;
+        int i2 = i - 1;
+        return interpolate(mCurrentBrightness, iArr[i2][0], iArr[i][0], iArr[i2][1], iArr[i][1]);
+    }
+
+    public void updateIconDim() {
+        if (!mIsCircleShowing && mTargetUsesInKernelDimming) {
+            setColorFilter(Color.argb(getDimAlpha(), 0, 0, 0), PorterDuff.Mode.SRC_ATOP);
+        } else {
+            setColorFilter(Color.argb(0, 0, 0, 0), PorterDuff.Mode.SRC_ATOP);
+        }
     }
 
     @Override
@@ -322,6 +389,7 @@ public class FODCircleView extends ImageView {
         dispatchPress();
 
         setImageDrawable(null);
+        updateIconDim();
         invalidate();
     }
 
@@ -350,14 +418,15 @@ public class FODCircleView extends ImageView {
 
         updatePosition();
 
-        updatePosition();
-
-        dispatchShow();
+        Dependency.get(TunerService.class).addTunable(this, SCREEN_BRIGHTNESS);
+        
+	dispatchShow();
         setVisibility(View.VISIBLE);
     }
 
     public void hide() {
         setVisibility(View.GONE);
+        Dependency.get(TunerService.class).removeTunable(this);
         hideCircle();
         dispatchHide();
     }

--- a/packages/SystemUI/src/com/android/systemui/biometrics/FODCircleView.java
+++ b/packages/SystemUI/src/com/android/systemui/biometrics/FODCircleView.java
@@ -314,12 +314,12 @@ public class FODCircleView extends ImageView implements TunerService.Tunable {
                 });
                 anim.setDuration(1000);
                 mIsAnimating = true;
-                anim.start();
+                mHandler.post(() -> anim.start());
             } else if (!mIsAnimating) {
                 setColorFilter(Color.argb(getDimAlpha(), 0, 0, 0), PorterDuff.Mode.SRC_ATOP);
             }
         } else {
-            setColorFilter(Color.argb(0, 0, 0, 0), PorterDuff.Mode.SRC_ATOP);
+            mHandler.post(() -> setColorFilter(Color.argb(0, 0, 0, 0), PorterDuff.Mode.SRC_ATOP));
         }
     }
 


### PR DESCRIPTION
## FODCircleView: update position of icon before show

FOD icon can appear in the wrong position when locking
the device while in landscape.
Fix it by updating the position before showing.

Change-Id: I812aa07357eadf8ff371761c041e44f5aab48046

## FODCircleView: Dim FOD icon

Change-Id: Ic8bb03ae2af68c877f41510068f3d9e307193384

## SystemUI: FODCircleView: Animate the icon dim

Also make sure we dim the icon back after a press

## FODCircleView: Apply color filter to FOD background

Signed-off-by: Pranav Vashi <neobuddy89@gmail.com>
Change-Id: I5fbc23a9c8ce7c7446695c016e9659e0cd5d7214

## FODCircleView: Post calls of main hal functions on background thread

Change-Id: Ie3175fd143a83a87f985e3cb3a668b9d589c5903

## FODCircleView: Use Handler for Icon dim color filter


## FODCircleView: Enable hardware acceleration


## FODCircleView: Use a ContentObserver to check screen brightness

Change-Id: I90083162ca81c249fe462a32b92baf4b498e8e46

## FODCircleView: Update FOD icon position on DreamingStateChanged

* Currently the icon doesn't switch back to its original
  position when coming back to lockscreen from AOD. This
  patch fixes it by updating the FOD icon position when
  the dreaming state is changed.
* See: https://imgur.com/a/LvaWMBM

Change-Id: Iff7d9c68d05ef860e18f101d9aaca68254ba5667