### PR TITLE
BurnInProtection: Fix null object reference with timer

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/policy/BurnInProtectionController.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/policy/BurnInProtectionController.java
@@ -91,6 +91,7 @@ public class BurnInProtectionController {
 
     public void stopSwiftTimer() {
         if (!mSwiftEnabled) return;
+        if (mTimer == null) return;
         mTimer.cancel();
         mTimer.purge();
         mTimer = null;


### PR DESCRIPTION
`java.lang.NullPointerException,Attempt to invoke virtual method 'void java.util.Timer.cancel()' on a null object reference,BurnInProtectionController.java,94`