### PR TITLE
core: Spoof build properties

### DIFF
--- a/core/java/android/app/Instrumentation.java
+++ b/core/java/android/app/Instrumentation.java
@@ -41,6 +41,7 @@ import android.os.Process;
 import android.os.RemoteException;
 import android.os.ServiceManager;
 import android.os.SystemClock;
+import android.os.SystemProperties;
 import android.os.TestLooperManager;
 import android.os.UserHandle;
 import android.util.AndroidRuntimeException;
@@ -60,6 +61,7 @@ import com.android.internal.content.ReferrerIntent;
 import java.io.File;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -1157,6 +1159,7 @@ public class Instrumentation {
         Application app = getFactory(context.getPackageName())
                 .instantiateApplication(cl, className);
         app.attach(context);
+        maybeSpoofBuild(app);
         return app;
     }
     
@@ -1174,9 +1177,41 @@ public class Instrumentation {
             ClassNotFoundException {
         Application app = (Application)clazz.newInstance();
         app.attach(context);
+        maybeSpoofBuild(app);
         return app;
     }
 
+ private static void setBuildField(String packageName, String key, String value) {
+        /*
+         * This would be much prettier if we just removed "final" from the Build fields,
+         * but that requires changing the API.
+         *
+         * While this an awful hack, it's technically safe because the fields are
+         * populated at runtime.
+         */
+        try {
+            // Unlock
+            Field field = Build.class.getDeclaredField(key);
+            field.setAccessible(true);
+
+            // Edit
+            field.set(null, value);
+
+            // Lock
+            field.setAccessible(false);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            Log.e(TAG, "Failed to spoof Build." + key + " for " + packageName, e);
+        }
+    }
+
+    private static void maybeSpoofBuild(Application app) {
+        String packageName = app.getPackageName();
+
+        // Set MODEL to "Pixel 4a (5G)"
+        if ("com.google.android.gms".equals(packageName)) {
+            setBuildField(packageName, "MODEL", "Pixel 4a (5G)");
+        }
+    }
     /**
      * Perform calling of the application's {@link Application#onCreate}
      * method.  The default implementation simply calls through to that method.


### PR DESCRIPTION
SafetyNet's CTS profile attestation checks whether Build.MODEL matches
that of the device's stock OS and checking whether it's a device that
matched the CTS Profile.

Spoof the model by setting Build.MODEL to "Pixel 4a (5G)" for
Google Play Services to help pass SafetyNet.

REF: ProtonAOSP/android_frameworks_base@b8adfb5
BUG: h/gourami/labs/c/1539827478/6247
BUG: h/gourami/labs/c/1539827478/6259
BUG: h/hoyo/labs/int/a/187
[Raphiel] : Reworded commit description for our usecase

Change-Id: I491e5f555a71a7cdef0ab4ca15cef7cd73e9eaaf